### PR TITLE
allow cards in player's hand to be selected

### DIFF
--- a/Ten Penny Game/Assets/Scenes/SampleScene.unity
+++ b/Ten Penny Game/Assets/Scenes/SampleScene.unity
@@ -1119,7 +1119,6 @@ MonoBehaviour:
   - {fileID: 21300000, guid: cb84a51d3c79fcd48b8e2f978d46991a, type: 3}
   - {fileID: 21300000, guid: e615af29c0750df4bb16deaf526950d1, type: 3}
   - {fileID: 21300000, guid: 4a0fbe345c7052f4380e24da48ddae10, type: 3}
-  playerHandPos: {fileID: 1010075822}
 --- !u!4 &1765491947
 Transform:
   m_ObjectHideFlags: 0

--- a/Ten Penny Game/Assets/Scripts/PlayerHand.cs
+++ b/Ten Penny Game/Assets/Scripts/PlayerHand.cs
@@ -7,12 +7,14 @@ public class PlayerHand : MonoBehaviour
 {
     public List<string> cardList {get;}
     public List<GameObject> cardObjectList {get;}
+    public List<GameObject> selectedCards {get;}
     public GameObject cardPrefab;
     
     public PlayerHand()
     {
         this.cardList = new List<string>();
         this.cardObjectList = new List<GameObject>();
+        this.selectedCards = new List<GameObject>();
     }
 
     public void DisplayHand()
@@ -42,6 +44,7 @@ public class PlayerHand : MonoBehaviour
     {
         foreach (GameObject card in this.cardObjectList)
         {
+            this.selectedCards.Remove(card);
             Destroy(card);
         }
     }
@@ -99,5 +102,19 @@ public class PlayerHand : MonoBehaviour
             return 1;
         }
         return c2value - c1value;
+    }
+
+    public Color SelectCard(GameObject card)
+    {
+        if (this.selectedCards.Contains(card) == false)
+        {
+            this.selectedCards.Add(card);
+            return Color.yellow;
+        }
+        else
+        {
+            this.selectedCards.Remove(card);
+            return Color.white;
+        }
     }
 }

--- a/Ten Penny Game/Assets/Scripts/TenPenny.cs
+++ b/Ten Penny Game/Assets/Scripts/TenPenny.cs
@@ -83,4 +83,10 @@ public class TenPenny : MonoBehaviour
             this.playerHand.RefreshHand();
         }
     }
+
+    public void SelectPlayerCard(GameObject card)
+    {
+        Color colour = this.playerHand.SelectCard(card);
+        card.GetComponent<UpdateSprite>().SetColour(colour);
+    }
 }

--- a/Ten Penny Game/Assets/Scripts/UpdateSprite.cs
+++ b/Ten Penny Game/Assets/Scripts/UpdateSprite.cs
@@ -41,4 +41,9 @@ public class UpdateSprite : MonoBehaviour
             spriteRenderer.sprite = cardBack;
         }
     }
+
+    public void SetColour(Color colour)
+    {
+        spriteRenderer.color = colour;
+    }
 }

--- a/Ten Penny Game/Assets/Scripts/UserInput.cs
+++ b/Ten Penny Game/Assets/Scripts/UserInput.cs
@@ -6,6 +6,7 @@ public class UserInput : MonoBehaviour
 {
     public RaycastHit2D mouseDownHit;
     public RaycastHit2D mouseUpHit;
+    public RaycastHit2D lastMouseUpHit;
     private TenPenny tenPenny;
     private float timer;
     private static float doubleClickTime = 0.3f;
@@ -48,6 +49,7 @@ public class UserInput : MonoBehaviour
         }
         else if (Input.GetMouseButtonUp(0))
         {
+            this.lastMouseUpHit = this.mouseUpHit;
             this.mouseUpHit = UserInput.GetHit();
             if (this.mouseUpHit && this.mouseDownHit)
             {
@@ -76,7 +78,8 @@ public class UserInput : MonoBehaviour
 
     private bool IsDoubleClick()
     {
-        if (this.timer < doubleClickTime && this.clickCount == 2)
+        if (this.timer < doubleClickTime && this.clickCount == 2 &&
+            this.mouseUpHit.collider.ToString() == this.lastMouseUpHit.collider.ToString())
         {
             print("Double-Click");
             return true;
@@ -109,6 +112,10 @@ public class UserInput : MonoBehaviour
         if (IsDoubleClick())
         {
             this.tenPenny.DiscardCardFromPlayerHand(this.mouseUpHit.collider.name);
+        }
+        else
+        {
+            this.tenPenny.SelectPlayerCard(this.mouseUpHit.collider.gameObject);
         }
     }
 

--- a/Ten Penny Game/Assets/Tests/PlayMode_Tests/PlayerHand_Tests.cs
+++ b/Ten Penny Game/Assets/Tests/PlayMode_Tests/PlayerHand_Tests.cs
@@ -65,5 +65,45 @@ namespace Tests
             Assert.AreEqual(cardList[9], "D2");
             Assert.AreEqual(cardList[10], "2JOKER");
         }
+
+        [Test]
+        public void SelectCard_Test()
+        {
+            PlayerHand hand = new GameObject().AddComponent<PlayerHand>();
+            List<GameObject> selectedCards = hand.selectedCards;
+
+            GameObject cardC1 = new GameObject();
+            GameObject cardS4 = new GameObject();
+            GameObject cardH11 = new GameObject();
+
+            Assert.AreEqual(Color.yellow, hand.SelectCard(cardC1));
+            Assert.AreEqual(selectedCards.Count, 1);
+            Assert.AreEqual(selectedCards[0], cardC1);
+
+            Assert.AreEqual(Color.yellow, hand.SelectCard(cardS4));
+            Assert.AreEqual(selectedCards.Count, 2);
+            Assert.AreEqual(selectedCards[0], cardC1);
+            Assert.AreEqual(selectedCards[1], cardS4);
+
+            Assert.AreEqual(Color.white, hand.SelectCard(cardC1));
+            Assert.AreEqual(selectedCards.Count, 1);
+            Assert.AreEqual(selectedCards[0], cardS4);
+
+            Assert.AreEqual(Color.yellow, hand.SelectCard(cardH11));
+            Assert.AreEqual(selectedCards.Count, 2);
+            Assert.AreEqual(selectedCards[0], cardS4);
+            Assert.AreEqual(selectedCards[1], cardH11);
+
+            Assert.AreEqual(Color.yellow, hand.SelectCard(cardC1));
+            Assert.AreEqual(selectedCards.Count, 3);
+            Assert.AreEqual(selectedCards[0], cardS4);
+            Assert.AreEqual(selectedCards[1], cardH11);
+            Assert.AreEqual(selectedCards[2], cardC1);
+
+            Assert.AreEqual(Color.white, hand.SelectCard(cardH11));
+            Assert.AreEqual(selectedCards.Count, 2);
+            Assert.AreEqual(selectedCards[0], cardS4);
+            Assert.AreEqual(selectedCards[1], cardC1);
+        }
     }
 }


### PR DESCRIPTION
Multiple cards can be selected. Clicking a selected card will deselect it. Any action that refreshes the hand (such as sorting or discarding a card) will deselect all cards.